### PR TITLE
feat: add dark/light mode toggle functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <button class="theme-toggle" aria-label="Toggle theme" title="Toggle light/dark mode">🌙</button>
     <div class="calculator-container" role="application" aria-label="Calculator">
         <div class="display" role="textbox" aria-live="polite" aria-atomic="true">0</div>
         <div class="buttons">

--- a/script.js
+++ b/script.js
@@ -1,10 +1,47 @@
 document.addEventListener('DOMContentLoaded', () => {
     const display = document.querySelector('.display');
     const buttons = document.querySelector('.buttons');
+    const themeToggle = document.querySelector('.theme-toggle');
     let currentInput = '0';
     let operator = null;
     let previousInput = '';
     let resetDisplay = false;
+
+    // Theme toggle functionality
+    function toggleTheme() {
+        const root = document.documentElement;
+        const isLightMode = root.classList.contains('light-theme');
+        
+        if (isLightMode) {
+            root.classList.remove('light-theme');
+            themeToggle.textContent = '🌙';
+            localStorage.setItem('theme', 'dark');
+        } else {
+            root.classList.add('light-theme');
+            themeToggle.textContent = '☀️';
+            localStorage.setItem('theme', 'light');
+        }
+    }
+
+    // Initialize theme from localStorage
+    function initializeTheme() {
+        const savedTheme = localStorage.getItem('theme');
+        const root = document.documentElement;
+        
+        if (savedTheme === 'light') {
+            root.classList.add('light-theme');
+            themeToggle.textContent = '☀️';
+        } else {
+            root.classList.remove('light-theme');
+            themeToggle.textContent = '🌙';
+        }
+    }
+
+    // Initialize theme on page load
+    initializeTheme();
+
+    // Theme toggle event listener
+    themeToggle.addEventListener('click', toggleTheme);
 
     buttons.addEventListener('click', (event) => {
         const target = event.target;

--- a/style.css
+++ b/style.css
@@ -10,6 +10,27 @@
     --clear-hover-bg: #bf3f3f;
     --equals-bg: #28a745;
     --equals-hover-bg: #218838;
+    --body-bg: #f4f4f4;
+    --toggle-bg: #666;
+    --toggle-hover-bg: #888;
+}
+
+/* Light theme */
+:root.light-theme {
+    --calc-bg: #f9f9f9;
+    --display-bg: #ffffff;
+    --text-color: #333;
+    --button-bg: #e0e0e0;
+    --button-hover-bg: #d0d0d0;
+    --operator-bg: #f7921a;
+    --operator-hover-bg: #e08016;
+    --clear-bg: #ff6b6b;
+    --clear-hover-bg: #ff5252;
+    --equals-bg: #4caf50;
+    --equals-hover-bg: #45a049;
+    --body-bg: #e8e8e8;
+    --toggle-bg: #666;
+    --toggle-hover-bg: #888;
 }
 
 body {
@@ -17,7 +38,7 @@ body {
     justify-content: center;
     align-items: center;
     min-height: 100vh;
-    background-color: #f4f4f4;
+    background-color: var(--body-bg);
     margin: 0;
     font-family: Arial, sans-serif;
 }
@@ -98,6 +119,30 @@ body {
 .buttons button.active {
     box-shadow: 0 0 10px rgba(255, 255, 255, 0.7);
     transform: scale(0.98);
+}
+
+/* Theme toggle button */
+.theme-toggle {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    background-color: var(--toggle-bg);
+    color: var(--text-color);
+    border: none;
+    border-radius: 50%;
+    width: 50px;
+    height: 50px;
+    font-size: 1.5em;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+}
+
+.theme-toggle:hover {
+    background-color: var(--toggle-hover-bg);
 }
 
 /* Responsive Design */


### PR DESCRIPTION
This PR implements a UI feature to toggle between dark mode and light mode for the calculator application.

## Changes
- Added light theme CSS variables
- Added floating theme toggle button with moon/sun icons
- Implemented theme switching with localStorage persistence
- Maintained all existing calculator functionality
- Added proper accessibility attributes

## How to Test
1. Open the calculator in your browser
2. Click the theme toggle button in the top-right corner
3. Verify it switches between dark (🌙) and light (☀️) modes
4. Refresh the page to confirm theme persistence

Fixes #2

Generated with [Claude Code](https://claude.ai/code)